### PR TITLE
Add CIM compliance for the Authentication datamodel

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -1,10 +1,10 @@
 [install]
-build = 1.0
+build = 1.1
 
 [launcher]
 description = DUO Security Log Add-on for Splunk
 author = bawood
-version = 1.0.0
+version = 1.1.0
 
 [ui]
 is_visible = 0

--- a/default/props.conf
+++ b/default/props.conf
@@ -1,0 +1,4 @@
+[duo:authentication]
+FIELDALIAS-cim_aliases = integration AS dest ip AS src_ip username AS user
+EVAL-app = "duo"
+LOOKUP-duo_action = duo_action result AS result OUTPUTNEW action AS action

--- a/default/tags.conf
+++ b/default/tags.conf
@@ -1,0 +1,2 @@
+[sourcetype=duo%3Aauthentication]
+authentication = enabled

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -1,0 +1,2 @@
+[duo_action]
+filename = duo_action.csv

--- a/lookups/duo_action.csv
+++ b/lookups/duo_action.csv
@@ -1,0 +1,3 @@
+result,action
+SUCCESS,success
+FAILURE,failure


### PR DESCRIPTION
These changes make the duo:authentication sourcetype  CIM compliant so that they can be easily ingested by Enterprise Security (and other CIM-dependent Splunk apps). ([https://docs.splunk.com/Documentation/CIM/4.5.0/User/Authentication](url)). 
