### PR TITLE
Update props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -1,4 +1,6 @@
 [duo:authentication]
+TIME_PREFIX=\"isotimestamp\"\:
+TIME_FORMAT=%Y-%m-%dT%H:%M:%S.%6N%Z
 FIELDALIAS-duo_app = integration AS app
 FIELDALIAS-duo_user = username AS user
 FIELDALIAS-duo_ = ip AS src


### PR DESCRIPTION
Added TIME_PREFIX and TIME_FORMAT as the time zone and microseconds were not correctly interpreted by Splunk out of the box.
This is also a best practice.